### PR TITLE
Updates to ISLE behat suite to facilitate institutional tests

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -12,7 +12,7 @@ default: # Our DEFAULT profile targets the APACHE container with the @apache tag
               assets_path: "%paths.base%/features/assets/"
 
       filters:
-        tags: "@apache"
+        tags: "@apache&&~@disabled"
   extensions:
     Behat\MinkExtension:
       base_url: http://apache
@@ -90,7 +90,7 @@ solr: # SOLR profile
   suites:
     default:
       filters:
-        tags: "@solr"
+        tags: "@solr&&~@disabled"
   extensions:
     Behat\MinkExtension:
       base_url: http://solr:8080
@@ -99,7 +99,7 @@ traefik: # TRAEFIK profile
   suites:
     default:
       filters:
-        tags: "@traefik"
+        tags: "@traefik&&~@disabled"
   extensions:
     Behat\MinkExtension:
       base_url: http://traefik:8080
@@ -108,7 +108,7 @@ fedora: # FEDORA profile
   suites:
     default:
       filters:
-        tags: "@fedora"
+        tags: "@fedora&&~@disabled"
   extensions:
     Behat\MinkExtension:
       base_url: http://fedora:8080
@@ -117,7 +117,7 @@ imageservices: # IMAGESERVICES profile
   suites:
     default:
       filters:
-        tags: "@imageservices"
+        tags: "@imageservices&&~@disabled"
   extensions:
     Behat\MinkExtension:
       base_url: http://image-services:8080
@@ -126,7 +126,7 @@ portainer: # PORTAINER profile
   suites:
     default:
       filters:
-        tags: "@portainer"
+        tags: "@portainer&&~@disabled"
   extensions:
     Behat\MinkExtension:
       base_url: http://isle-portainer:9000
@@ -135,7 +135,7 @@ mysql: # MYSQL profile
   suites:
     default:
       filters:
-        tags: "@mysql"
+        tags: "@mysql&&~@disabled"
   extensions:
     Behat\MinkExtension:
       base_url: http://mysql:3306

--- a/features/audio.feature
+++ b/features/audio.feature
@@ -49,9 +49,8 @@ Feature: Test Audio CModel
     Then I click on the selector "#edit-next"
     # And wait for the page to be loaded
     Then wait for Ingest to complete
+    Then wait for Ingest to complete
     # Then wait for Ingest to complete
-    # Then wait for Ingest to complete
-    Then grab me a screenshot
     # Make sure the object ingested
     Given I am on "/islandora/search/%22Z%20%28Audio%29%20TEST%22?type=dismax"
     Then I should see "Z (Audio) TEST"

--- a/features/audio.feature
+++ b/features/audio.feature
@@ -51,7 +51,6 @@ Feature: Test Audio CModel
     Then wait for Ingest to complete
     # Make sure the object ingested
     Given I am on "/islandora/search/%22Z%20%28Audio%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (Audio) TEST"
 
 

--- a/features/audio.feature
+++ b/features/audio.feature
@@ -246,7 +246,9 @@ Feature: Test Audio CModel
     And wait 5 seconds
     # Test that object title did change and that search picks it up
     Given I am on "/islandora/search/%22Z%20%28Audio%29%20TEST%20EDITED%22?type=dismax"
+    Then grab me a screenshot
     Then I should see "Z (Audio) TEST EDITED"
+    Then grab me a screenshot
     # Then I should see "behattest:"
     # Change Object title back to original
     # Given that I navigate to the page for the object named "Z (Audio) TEST"

--- a/features/audio.feature
+++ b/features/audio.feature
@@ -49,6 +49,9 @@ Feature: Test Audio CModel
     Then I click on the selector "#edit-next"
     # And wait for the page to be loaded
     Then wait for Ingest to complete
+    # Then wait for Ingest to complete
+    # Then wait for Ingest to complete
+    Then grab me a screenshot
     # Make sure the object ingested
     Given I am on "/islandora/search/%22Z%20%28Audio%29%20TEST%22?type=dismax"
     Then I should see "Z (Audio) TEST"
@@ -137,6 +140,8 @@ Feature: Test Audio CModel
     Then I press "Regenerate all derivatives"
     Then I should see "This will create a new version for every datastream on the object. Please wait while this happens."
     Given I press "Regenerate"
+    Then wait for Ingest to complete
+    Then wait for Ingest to complete
     Then wait for Ingest to complete
     Then I should see the link "Derivatives successfully created"
     Given I click "Derivatives successfully created"

--- a/features/audio.feature
+++ b/features/audio.feature
@@ -243,11 +243,14 @@ Feature: Test Audio CModel
     Then I fill in "edit-titleinfo-title" with "Z (Audio) TEST EDITED"
     When I press "Update"
     Then I should see "Z (Audio) TEST EDITED"
+    And wait 5 seconds
     # Test that object title did change and that search picks it up
-    Given I am on "/islandora/search/Z%20%28Audio%29%20TEST%20EDITED?type=dismax"
-    Then I should see "behattest:"
+    Given I am on "/islandora/search/%22Z%20%28Audio%29%20TEST%20EDITED%22?type=dismax"
+    Then I should see "Z (Audio) TEST EDITED"
+    # Then I should see "behattest:"
     # Change Object title back to original
-    Given that I navigate to the page for the object named "Z (Audio) TEST"
+    # Given that I navigate to the page for the object named "Z (Audio) TEST"
+    Then I click "Z (Audio) TEST EDITED"
     Then I should see "Z (Audio) TEST EDITED"
     Then I click "Manage"
     Then I click "Datastreams"
@@ -258,8 +261,9 @@ Feature: Test Audio CModel
     When I press "Update"
     Then I should see "Z (Audio) TEST"
     # Check that object title is original and that search is picking it up
-    Given I am on "/islandora/search/Z%20%28Audio%29%20TEST?type=dismax"
-    Then I should see "behattest:"
+    Given I am on "/islandora/search/%22Z%20%28Audio%29%20TEST%22?type=dismax"
+    # Then I should see "behattest:"
+    Then I should see "Z (Audio) TEST"
 
 
     # Able to edit the Item Label of an AUDIO object's Properties?
@@ -298,7 +302,6 @@ Feature: Test Audio CModel
     #Given I am logged in as a user with the "administrator" role
     Given that I navigate to the page for the object named "Z (Audio) TEST"
     # Delete new object
-    Then I should see "In collections"
     When I click "Manage"
     Then I click "Properties"
     Then I should see "Item Label"
@@ -314,7 +317,9 @@ Feature: Test Audio CModel
     Then I press "Clear all caches"
     And wait 5 seconds
     Given I am on "/islandora/search/%22Z%20%28Audio%29%20TEST%22?type=dismax"
-    Then I should see "(0 - 0 of 0)"
+    # Then I should see "(0 - 0 of 0)"
+    # For Colgate replace with "Then I should see "Sorry, but your search returned no results.""
+    Then I should see "Sorry, but your search returned no results."
 
 
     # @api @apache @javascript @audio

--- a/features/audio.feature
+++ b/features/audio.feature
@@ -317,9 +317,7 @@ Feature: Test Audio CModel
     Then I press "Clear all caches"
     And wait 5 seconds
     Given I am on "/islandora/search/%22Z%20%28Audio%29%20TEST%22?type=dismax"
-    # Then I should see "(0 - 0 of 0)"
-    # For Colgate replace with "Then I should see "Sorry, but your search returned no results.""
-    Then I should see "Sorry, but your search returned no results."
+    Then I should see "(0 - 0 of 0)"
 
 
     # @api @apache @javascript @audio

--- a/features/basicimage.feature
+++ b/features/basicimage.feature
@@ -228,7 +228,8 @@ Feature: Test BasicImage CModel
     Then I click on the selector "#edit-update"
     Then I should see "Z (Basic Image) TEST EDITED"
     # Test that object title did change and that search picks it up
-    Given the cache has been cleared
+    # Given the cache has been cleared
+    And wait 5 seconds
     Given I am on "/islandora/search/%22Z%20%28Basic%20Image%29%20TEST%20EDITED%22?type=dismax"
     # Then I should see "behattest:"
     Then I should see "Z (Basic Image) TEST EDITED"

--- a/features/basicimage.feature
+++ b/features/basicimage.feature
@@ -228,7 +228,8 @@ Feature: Test BasicImage CModel
     Then I click on the selector "#edit-update"
     Then I should see "Z (Basic Image) TEST EDITED"
     # Test that object title did change and that search picks it up
-    Given I am on "/islandora/search/Z%20%28Basic%20Image%29%20TEST%20EDITED?type=dismax"
+    Given the cache has been cleared
+    Given I am on "/islandora/search/%22Z%20%28Basic%20Image%29%20TEST%20EDITED%22?type=dismax"
     # Then I should see "behattest:"
     Then I should see "Z (Basic Image) TEST EDITED"
     # Change Object title back to original

--- a/features/basicimage.feature
+++ b/features/basicimage.feature
@@ -47,7 +47,6 @@ Feature: Test BasicImage CModel
 
     #Given I am logged in as a user with the "administrator" role
     Given I am on "/islandora/search/%22Z%20%28Basic%20Image%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (Basic Image) TEST"
 
 

--- a/features/basicimage.feature
+++ b/features/basicimage.feature
@@ -30,7 +30,6 @@ Feature: Test BasicImage CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    #Then I should see "MARCXML File"
     # Then I press "Next"
     Then I click on the selector "#edit-next"
 

--- a/features/basicimage.feature
+++ b/features/basicimage.feature
@@ -30,7 +30,7 @@ Feature: Test BasicImage CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    Then I should see "MARCXML File"
+    #Then I should see "MARCXML File"
     # Then I press "Next"
     Then I click on the selector "#edit-next"
 
@@ -228,10 +228,12 @@ Feature: Test BasicImage CModel
     Then I click on the selector "#edit-update"
     Then I should see "Z (Basic Image) TEST EDITED"
     # Test that object title did change and that search picks it up
-    Given I am on "/islandora/search/Z%20%28Basic%20Image%29%20TEST%20EDITED?type=dismax"
-    Then I should see "behattest:"
+    Given I am on "/islandora/search/%22Z%20%28Basic%20Image%29%20TEST%20EDITED%22?type=dismax"
+    # Then I should see "behattest:"
+    Then I should see "Z (Basic Image) TEST EDITED"
     # Change Object title back to original
-    Given that I navigate to the page for the object named "Z (Basic Image) TEST"
+    # Given that I navigate to the page for the object named "Z (Basic Image) TEST"
+    Then I click "Z (Basic Image) TEST EDITED"
     Then I should see "Z (Basic Image) TEST EDITED"
     Then I click "Manage"
     Then I click "Datastreams"
@@ -242,8 +244,8 @@ Feature: Test BasicImage CModel
     Then I click on the selector "#edit-update"
     Then I should see "Z (Basic Image) TEST"
     # Check that object title is original and that search is picking it up
-    Given I am on "/islandora/search/Z%20%28Basic%20Image%29%20TEST?type=dismax"
-    Then I should see "behattest:"
+    Given I am on "/islandora/search/%22Z%20%28Basic%20Image%29%20TEST%22?type=dismax"
+    # Then I should see "behattest:"
 
 
     ## Able to edit the Item Label of an Basic Image object's Properties?
@@ -282,7 +284,6 @@ Feature: Test BasicImage CModel
     #Given I am logged in as a user with the "administrator" role
     Given that I navigate to the page for the object named "Z (Basic Image) TEST"
     # Delete new object
-    Then I should see "In collections"
     When I click "Manage"
     Then I click "Properties"
     Then I should see "Item Label"

--- a/features/basicimage.feature
+++ b/features/basicimage.feature
@@ -228,7 +228,7 @@ Feature: Test BasicImage CModel
     Then I click on the selector "#edit-update"
     Then I should see "Z (Basic Image) TEST EDITED"
     # Test that object title did change and that search picks it up
-    Given I am on "/islandora/search/%22Z%20%28Basic%20Image%29%20TEST%20EDITED%22?type=dismax"
+    Given I am on "/islandora/search/Z%20%28Basic%20Image%29%20TEST%20EDITED?type=dismax"
     # Then I should see "behattest:"
     Then I should see "Z (Basic Image) TEST EDITED"
     # Change Object title back to original

--- a/features/book.feature
+++ b/features/book.feature
@@ -249,10 +249,12 @@ Feature: Test Book CModel
     When I press "Update"
     Then I should see "Z (BOOK) TEST EDITED"
     # Test that object title did change and that search picks it up
-    Given I am on "/islandora/search/Z%20%28BOOK%29%20TEST%20EDITED?type=dismax"
-    Then I should see "behattest:"
+    Given I am on "/islandora/search/%22Z%20%28BOOK%29%20TEST%20EDITED%22?type=dismax"
+    # Then I should see "behattest:"
+    Then I should see "Z (BOOK) TEST EDITED"
     # Change Object title back to original
-    Given that I navigate to the page for the object named "Z (BOOK) TEST"
+    # Given that I navigate to the page for the object named "Z (BOOK) TEST"
+    Then I click "Z (BOOK) TEST EDITED"
     Then I should see "Z (BOOK) TEST EDITED"
     Then I click "Manage"
     Then I click "Datastreams"
@@ -263,8 +265,8 @@ Feature: Test Book CModel
     Then I click on the selector "#edit-update"
     Then I should see "Z (BOOK) TEST"
     # Check that object title is original and that search is picking it up
-    Given I am on "/islandora/search/Z%20%28BOOK%29%20TEST?type=dismax"
-    Then I should see "behattest:"
+    Given I am on "/islandora/search/%22Z%20%28BOOK%29%20TEST%22?type=dismax"
+    # Then I should see "behattest:"
     # similar test for "replace"
 
 

--- a/features/book.feature
+++ b/features/book.feature
@@ -306,7 +306,6 @@ Feature: Test Book CModel
     #Given I am logged in as a user with the "administrator" role
     Given that I navigate to the page for the object named "Z (BOOK) TEST"
     # Delete new object
-    Then I should see the link "Pages"
     When I click "Manage"
     Then I click "Properties"
     Then I should see "Item Label"

--- a/features/book.feature
+++ b/features/book.feature
@@ -249,6 +249,7 @@ Feature: Test Book CModel
     When I press "Update"
     Then I should see "Z (BOOK) TEST EDITED"
     # Test that object title did change and that search picks it up
+    And wait 5 seconds
     Given I am on "/islandora/search/%22Z%20%28BOOK%29%20TEST%20EDITED%22?type=dismax"
     # Then I should see "behattest:"
     Then I should see "Z (BOOK) TEST EDITED"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -512,18 +512,18 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   {
     # $this->getSession()->wait(1000*360*1.5);
     echo("Waiting until 'Manage' is visible again, max 10 minutes, in 1 minute increments: [");
-    $manage_test = '.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a';
+    // $manage_test = '.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a';
     
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
     echo("]");
   }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -514,16 +514,16 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     echo("Waiting until 'Manage' is visible again, max 10 minutes, in 1 minute increments: [");
     $manage_test = '.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a';
     
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery(" . $manage_test . ").length > 0) && (jQuery(" . $manage_test . ")[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
     echo("]");
   }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -512,16 +512,18 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   {
     # $this->getSession()->wait(1000*360*1.5);
     echo("Waiting until 'Manage' is visible again, max 10 minutes, in 1 minute increments: [");
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
-    echo($this->getSession()->wait(60000, "((jQuery('.tabs > li:nth-child(2) > a').length > 0) && (jQuery('.tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    $manage_test = '.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a';
+    
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
+    echo($this->getSession()->wait(60000, "((jQuery($manage_test).length > 0) && (jQuery($manage_test)[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
     echo("]");
   }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -653,22 +653,16 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     $repository = $connection->repository;
     $object = islandora_object_load($this->behat_test_collection_pid);
     if(empty($object)) {
-      throw new Exception("Unable to find the behat test collection in order to delete it.");
-    }
-    // try {
-    //   foreach($object as $datastream) {
-    //     $object->purgeDatastream($datastream->id);
-    //   }
-    // }
-    // catch(Exception $e) {
-    //   echo("WARNING: Could not purge test collection datastream: " . $datastream->id);
-    // }
-
-    try {
-      $repository->purgeObject($this->behat_test_collection_pid);
-    }
-    catch(Exception $e) {
-      throw new Exception("Could not purge the behat test collection. Message: " . $e->getMessage());
+      //throw new Exception("Unable to find the behat test collection in order to delete it.");
+      echo("WARNING: Unable to find the behat test collection in order to delete it.\n"); // this isn't actually worth failing for
+    } else {
+      try {
+        $repository->purgeObject($this->behat_test_collection_pid);
+      }
+      catch(Exception $e) {
+        //throw new Exception("Could not purge the behat test collection. Message: " . $e->getMessage());
+        echo("Could not purge the behat test collection. Message: " . $e->getMessage() . "\n");
+      }
     }
   }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -166,16 +166,26 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
       }
 
       $pid = $element->getText();
+
+      if(empty($pid)) {
+        throw new Exception("Could not navigate to the requested object: ".$pid);
+      }
+      echo("Navigating to: /islandora/object/". $pid);
+      $this->visitPath("/islandora/object/". $pid );
     }
     catch(Exception $e) {
-      throw new Exception($e->getMessage());
-    }
+      // not a default theme; try just clicking a link with that text
+      //$this->iClickTextInTheSelector($name, 'a');
 
-    if(empty($pid)) {
-      throw new Exception("Could not navigate to the requested object: ".$pid);
+      $element =  $session->getPage()->findLink($name);
+      if (null === $element) {
+        throw new \InvalidArgumentException(sprintf('Cannot find link with text: "%s"', $name));
+      } else {
+        echo("Navigating via clicking link: ". $name);
+        $element->click();
+      }
+      //throw new Exception($e->getMessage());
     }
-    echo("Navigating to: /islandora/object/". $pid);
-    $this->visitPath("/islandora/object/". $pid );
   }
 
   /**
@@ -513,7 +523,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     # $this->getSession()->wait(1000*360*1.5);
     echo("Waiting until 'Manage' is visible again, max 10 minutes, in 1 minute increments: [");
     // $manage_test = '.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a';
-    
+
     echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
     echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');
     echo($this->getSession()->wait(60000, "((jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a').length > 0) && (jQuery('.nav-tabs > li:nth-child(2) > a, .tabs > li:nth-child(2) > a')[0].innerText.toLowerCase().startsWith('manage')))") ? '.' : '/');

--- a/features/compound.feature
+++ b/features/compound.feature
@@ -341,7 +341,7 @@ Feature: Test Compound Object CModel
     #Given I am logged in as a user with the "administrator" role
     Given that I navigate to the page for the object named "Z (Compound Object) TEST"
     # Delete new object
-    Then I should see "In collections"
+    # Then I should see "In collections"
     When I click "Manage"
     Then I click "Properties"
     Then I should see "Item Label"
@@ -352,7 +352,7 @@ Feature: Test Compound Object CModel
     And wait 20 seconds
     # Delete first child object
     Given that I navigate to the page for the object named "Z (Compound Child) 1"
-    Then I should see "In collections"
+    # Then I should see "In collections"
     When I click "Manage"
     Then I click "Properties"
     Then I should see "Item Label"
@@ -363,7 +363,7 @@ Feature: Test Compound Object CModel
     And wait 20 seconds
     # Delete second child object
     Given that I navigate to the page for the object named "Z (Compound Child) 2"
-    Then I should see "In collections"
+    # Then I should see "In collections"
     When I click "Manage"
     Then I click "Properties"
     Then I should see "Item Label"

--- a/features/compound.feature
+++ b/features/compound.feature
@@ -31,7 +31,7 @@ Feature: Test Compound Object CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    # Then I should see "MARCXML File"
+    
     Then I click on the selector "#edit-next"
     Then I should see "Title"
     Then I fill in "edit-titleinfo-title" with "Z (Compound Child) 1"
@@ -58,7 +58,7 @@ Feature: Test Compound Object CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    # Then I should see "MARCXML File"
+    
     Then I click on the selector "#edit-next"
     Then I should see "Title"
     Then I fill in "edit-titleinfo-title" with "Z (Compound Child) 2"
@@ -84,7 +84,7 @@ Feature: Test Compound Object CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    # Then I should see "MARCXML File"
+    
     Then I click on the selector "#edit-next"
 
     Then I should see "Title"

--- a/features/compound.feature
+++ b/features/compound.feature
@@ -284,7 +284,8 @@ Feature: Test Compound Object CModel
     When I am on "/islandora/search/%22Z%20%28Compound%20Object%29%20TEST%22?type=dismax"
     # Test that object title did change and that search picks it up
     Given I am on "/islandora/search/Z%20%28Compound%20Object%29%20TEST%20EDITED?type=dismax"
-    Then I should see "behattest:"
+    #Then I should see "behattest:"
+    Then I should see "Z (Compound"
     # Change Object title back to original
     Given that I navigate to the page for the object named "Z (Compound Object) TEST"
     Then I should see "Z (Compound Child) 1"
@@ -298,7 +299,8 @@ Feature: Test Compound Object CModel
     Then I should see "Z (Compound Child) 1"
     # Check that object title is original and that search is picking it up
     Given I am on "/islandora/search/Z%20%28Compound%20Object%29%20TEST?type=dismax"
-    Then I should see "behattest:"
+    #Then I should see "behattest:"
+    Then I should see "Z (Compound"
     #similar test for "replace"
 
 

--- a/features/compound.feature
+++ b/features/compound.feature
@@ -46,7 +46,6 @@ Feature: Test Compound Object CModel
     ## Make sure the object ingested
     #Given I am logged in as a user with the "administrator" role
     When I am on "/islandora/search/%22Z%20%28Compound%20Child%29%201%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (Compound Child) 1"
     # Add second object
     And I am on "/islandora/object/behattest:collection"
@@ -74,7 +73,6 @@ Feature: Test Compound Object CModel
     ## Make sure the object ingested
     #Given I am logged in as a user with the "administrator" role
     When I am on "/islandora/search/%22Z%20%28Compound%20Child%29%202%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (Compound Child) 2"
     And I am on "/islandora/object/behattest:collection"
     Then I should see "Behat Test Collection"
@@ -98,7 +96,6 @@ Feature: Test Compound Object CModel
     ## Make sure the object ingested
     #Given I am logged in as a user with the "administrator" role
     When I am on "/islandora/search/%22Z%20%28Compound%20Object%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (Compound Object) TEST"
     Given that I navigate to the page for the object named "Z (Compound Object) TEST"
     And I click "Manage"
@@ -265,7 +262,6 @@ Feature: Test Compound Object CModel
     And wait 20 seconds
     Given the cache has been cleared
     When I am on "/islandora/search/%22Z%20%28Compound%20Object%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (Compound Object) TEST"
 
 
@@ -286,7 +282,6 @@ Feature: Test Compound Object CModel
     Then I click on the selector "#edit-update"
     Then I should see "Z (Compound Child) 1"
     When I am on "/islandora/search/%22Z%20%28Compound%20Object%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     # Test that object title did change and that search picks it up
     Given I am on "/islandora/search/Z%20%28Compound%20Object%29%20TEST%20EDITED?type=dismax"
     Then I should see "behattest:"
@@ -322,7 +317,6 @@ Feature: Test Compound Object CModel
     When I press "Update Properties"
     And wait 20 seconds
     When I am on "/islandora/search/%22Z%20%28Compound%20Object%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (Compound Object) TEST LABEL-EDITED"
     # Able to search for newly edited Item Label of an Compound Object object's Properties using Islandora simple search?
     Given I am on "/islandora/search/Z%20%28Compound%20Object%29%20TEST%20LABEL-EDITED?type=dismax"

--- a/features/compound.feature
+++ b/features/compound.feature
@@ -31,7 +31,7 @@ Feature: Test Compound Object CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    Then I should see "MARCXML File"
+    # Then I should see "MARCXML File"
     Then I click on the selector "#edit-next"
     Then I should see "Title"
     Then I fill in "edit-titleinfo-title" with "Z (Compound Child) 1"
@@ -58,7 +58,7 @@ Feature: Test Compound Object CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    Then I should see "MARCXML File"
+    # Then I should see "MARCXML File"
     Then I click on the selector "#edit-next"
     Then I should see "Title"
     Then I fill in "edit-titleinfo-title" with "Z (Compound Child) 2"
@@ -84,7 +84,7 @@ Feature: Test Compound Object CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    Then I should see "MARCXML File"
+    # Then I should see "MARCXML File"
     Then I click on the selector "#edit-next"
 
     Then I should see "Title"

--- a/features/isle-services.feature
+++ b/features/isle-services.feature
@@ -14,10 +14,10 @@ Feature: Test IsleServices
 
   # Able to view Portainer Admin panel?
   # http://isle-portainer:9000
-  @portainer
-  Scenario: portainer online
-    Given I am on "/"
-    Then I should see that the page title is "Portainer"
+  # @portainer
+  # Scenario: portainer online
+  #   Given I am on "/"
+  #   Then I should see that the page title is "Portainer"
 
   # Able to connect to MYQSL?
   # http://mysql:3306

--- a/features/largeimage.feature
+++ b/features/largeimage.feature
@@ -30,7 +30,7 @@ Feature: Test LargeImage CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    Then I should see "MARCXML File"
+    # Then I should see "MARCXML File"
     # Then I press "Next"
     Then I click on the selector "#edit-next"
 

--- a/features/largeimage.feature
+++ b/features/largeimage.feature
@@ -30,7 +30,7 @@ Feature: Test LargeImage CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    # Then I should see "MARCXML File"
+    
     # Then I press "Next"
     Then I click on the selector "#edit-next"
 

--- a/features/largeimage.feature
+++ b/features/largeimage.feature
@@ -48,7 +48,6 @@ Feature: Test LargeImage CModel
 
     #Given I am logged in as a user with the "administrator" role
     Given I am on "/islandora/search/%22Z%20%28Large%20Image%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (Large Image) TEST"
 
 

--- a/features/oralhistories.feature
+++ b/features/oralhistories.feature
@@ -53,7 +53,6 @@ Feature: Test ORAL HISTORIES CModel
     #Then grab me a screenshot
     # Make sure the object ingested
     Given I am on "/islandora/search/%22Z%20%28ORAL%20HISTORIES%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (ORAL HISTORIES) TEST"
 
 

--- a/features/pdf.feature
+++ b/features/pdf.feature
@@ -31,7 +31,7 @@ Feature: Test PDF CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    # Then I should see "MARCXML File"
+    
     # Then I press "Next"
     Then I click on the selector "#edit-next"
 

--- a/features/pdf.feature
+++ b/features/pdf.feature
@@ -31,7 +31,7 @@ Feature: Test PDF CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    Then I should see "MARCXML File"
+    # Then I should see "MARCXML File"
     # Then I press "Next"
     Then I click on the selector "#edit-next"
 

--- a/features/pdf.feature
+++ b/features/pdf.feature
@@ -55,7 +55,6 @@ Feature: Test PDF CModel
 
     #Given I am logged in as a user with the "administrator" role
     Given I am on "/islandora/search/%22Z%20%28PDF%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (PDF) TEST"
 
 

--- a/features/teardown-only.feature
+++ b/features/teardown-only.feature
@@ -1,0 +1,16 @@
+Feature: Teardown Only
+  In order to recover from an interrupted run
+  As a developer
+  Sometimes I need to be able to just run a teardown command
+
+  @api @apache @javascript @sample-teardown @teardown-only
+  Scenario: Just do enough to teardown again
+    Given I am logged in as a user with the "administrator" role
+    And I am on "/"
+    Then I should see a "body" element
+
+  @api @apache @javascript @sample-setup @sample-teardown @teardown-full
+  Scenario: Just setup then teardown
+    Given I am logged in as a user with the "administrator" role
+    And I am on "/"
+    Then I should see a "body" element

--- a/features/video.feature
+++ b/features/video.feature
@@ -31,7 +31,7 @@ Feature: Test Video CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    Then I should see "MARCXML File"
+    # Then I should see "MARCXML File"
     # Then I press "Next"
     Then I click on the selector "#edit-next"
 

--- a/features/video.feature
+++ b/features/video.feature
@@ -31,7 +31,7 @@ Feature: Test Video CModel
     And I wait for AJAX to finish
     Then I press "Next"
     And wait for the page to be loaded
-    # Then I should see "MARCXML File"
+    
     # Then I press "Next"
     Then I click on the selector "#edit-next"
 

--- a/features/video.feature
+++ b/features/video.feature
@@ -56,7 +56,6 @@ Feature: Test Video CModel
 
     #Given I am logged in as a user with the "administrator" role
     Given I am on "/islandora/search/%22Z%20%28Video%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (Video) TEST"
 
 

--- a/features/warc.feature
+++ b/features/warc.feature
@@ -52,7 +52,6 @@ Feature: Test WARC CModel
 
     # Make sure the object ingested
     Given I am on "/islandora/search/%22Z%20%28WARC%29%20TEST%22?type=dismax"
-    Then I should see "(1 - 1 of 1)"
     Then I should see "Z (WARC) TEST"
 
 


### PR DESCRIPTION
We have made the following changes to the universal behat suite to allow it to be run on a higher percentage of customized themes. We've removed assumptions which are specific to the plain vanilla Islandora 7 theme.

Changes:

- Removed portainer test since many folks won't run that in all environments
- Added an `@disabled` tag to allow folks to easily disable unwanted features
- Added tags to run for cleanup, to recover from failed test runs `@teardown-only` and `@teardown-full`
- Removed theme-specific search results phrasing tests
- Made the "find" command work better on customized themes